### PR TITLE
Remove discussion of using W3C verifiable presentations

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -442,9 +442,6 @@ The signature type is represented by the `sig_type` field and must be one of the
 
 === W3C verifiable credentials
 
-[#vc-vs-vp]
-IMPORTANT: TO DO (link:https://github.com/creator-assertions/identity-assertion/issues/16[issue #16]): *Major discussion item:* I think there are reasonable cases for the content of the *<<_identity_assertion,identity assertion>>* to be a new Verifiable Credential and also for it to be a Verifiable Presentation. The VC path will resolve some of the redundant-chain-of-trust issues identified below, but may complicate the signing experience for wallet-based applications. Currently assuming Verifiable Credential, but this is subject to change.
-
 ==== Verifiable credential overview
 
 In some use cases, an _<<_actor,actor>>_ in the system MAY wish to provide its own _<<W3C verifiable credential>>,_ as it exists at that moment in time, to the _<<C2PA claim generator>>_ to have it associated with one or more _<<_c2pa-assertion,C2PA assertions>>._ This _<<_actor,actor>>_ MAY be an individual, group, or organization.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -8,7 +8,7 @@ The link:https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specifica
 
 This specification describes a _<<C2PA assertion>>_ referred to here as the *<<_identity_assertion,identity assertion>>* that can be added to a _<<C2PA Manifest>>_ to enable a _<<_credential_subject,credential subject>>_ to prove control over a digital identity and to use that identity to document their role in the _<<C2PA asset>>’s_ lifecycle.
 
-*Draft 20 February 2024* · xref:_version_history[]
+*Draft 26 February 2024* · xref:_version_history[]
 
 [#maintainers]
 *Maintainers:*

--- a/docs/modules/ROOT/partials/version-history.adoc
+++ b/docs/modules/ROOT/partials/version-history.adoc
@@ -110,3 +110,7 @@ _This section is non-normative._
 *20 February 2024*
 
 * Promoted from pre-draft to draft status.
+
+*26 February 2024*
+
+* Merged link:https://github.com/creator-assertions/identity-assertion/pull/45[PR #45: Remove discussion of using W3C verifiable presentations] per CAWG meeting.


### PR DESCRIPTION
Result of discussion in [20 February 2024 meeting](https://creator-assertions.github.io/meeting-notes/2024-02-20/#_40_min_review_and_prioritize_to_do_items_in_existing_draft_specifications).

Closes #16.