### PR TITLE
Emphasizing the use of REGISTERED spots in the advertising use case

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -93,7 +93,7 @@ A human rights defender Jane manages to capture footage containing Content Crede
 
 ==== Election integrity and protecting political campaigns from deepfakes
 
-Aarav is the director of social communications for a political candidate in an upcoming election. He feels concerned that in efforts to manipulate voters, bad actors will create deepfake videos to misrepresent the candidate. To protect the campaign, Aarav decides that all official communications will be created, produced, and published with Content Credentials-enabled tools. The identity assertion equips Aarav and his team with the ability to represent the campaign as the organizational owner of the content that they publish. Aarav encourages voters to verify any digital campaign content to ensure that the material has Content Credentials that link the assets to the campaign.
+Aarav is the director of social communications for a political candidate in an upcoming election. He feels concerned that in efforts to manipulate voters, bad actors will create deepfake videos to misrepresent the candidate. To protect the campaign, Aarav decides that all official communications (which typically are registered with Ad-ID) will also be created, produced, and published with Content Credentials-enabled tools. The identity assertion equips Aarav and his team with the ability to represent the campaign as the organizational owner of the content that they publish. Aarav encourages voters to verify any digital campaign content to ensure that the material has Content Credentials that link the assets to the campaign.
 
 ==== Brand protection in digital marketing
 


### PR DESCRIPTION
The failure to acknowledge the contractual obligation (from Actors' Equity) to centrally register all commercial messages casts an unprofessional pall on characters described.