### PR TITLE
Remove W3C VC concepts from terms and definitions section

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -174,22 +174,6 @@ One or more cryptographic hashes that uniquely identifies either the entire _<<C
 
 Hard bindings are described in link:++https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specification.html#_hard_bindings++[Section 9.2, “Hard bindings,”] of the C2PA technical specification.
 
-=== Concepts adapted from W3C verifiable credentials specification
-
-The following definitions are adapted from the link:++https://www.w3.org/TR/vc-data-model/#terminology++[W3C verifiable credentials data model] specification, version 1.1. This specification uses the prefix “W3C” to denote concepts incorporated from that specification.
-
-==== W3C verifiable credential
-
-A tamper-evident credential that has authorship that can be cryptographically verified.
-
-==== W3C decentralized identifier
-
-A portable URL-based identifier, also known as a *DID,* associated with an entity. These identifiers are most often used in a _<<W3C verifiable credential>>_ and are associated with subjects such that a _<<W3C verifiable credential>>_ itself can be easily ported from one repository to another without the need to reissue the _<<W3C verifiable credential>>_. An example of a DID is `did:example:123456abcdef`.
-
-==== W3C decentralized identifier document
-
-Also referred to as a *DID document,* this is a document that is accessible using a verifiable data registry and contains information related to a specific _<<W3C decentralized identifier>>,_ such as the associated repository and public key information.
-
 === Concepts adapted from ToIP technical architecture
 
 The following definitions are adapted from the link:++https://github.com/trustoverip/TechArch/blob/v1-PR1/spec.md++[Trust over IP (ToIP) technology architecture specification]. This specification uses the prefix “ToIP” to denote concepts incorporated from that specification.


### PR DESCRIPTION
IMPORTANT: This should be restored in 1.x-add-vc branch. See #60.