### PR TITLE
Signer payload fixes

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -259,15 +259,28 @@ The schema for this type is defined by the `identity` rule in the following http
 ----
 identity = {
   "signer_payload": $signer-payload-map, ; content to be signed by credential holder
-  "sig_type": tstr .size (1..max-tstr-length), ; a string identifying the data type of the signature field that follows
   "signature": bstr, ; byte string of the signature
   "pad1": bstr, ; byte strings filled with binary `0x00` values used for filling up space
   ? "pad2": bstr, ; optional byte strings filled with binary `0x00` values used for filling up space
 }
 
 signer-payload-map = {
+  "sig_type": tstr .size (1..max-tstr-length), ; a string identifying the data type of the signature 
   "referenced_assertions": [1* $hashed-uri-map],
+  ? "signer_info": tstr .size (1..max-tstr-length), ; optional information about the signer 
+  ? "claim_certificate_hash": bstr, ; optional hash of the leaf-certificate of the key used to sign the claim
+  ? "id_certificate_hash" : [1* $hashed-cert-uri-map], ; optional hash of certificate of other ID assertion signers
 }
+; The data structure used to store a reference to a URL within the same JUMBF and its hash.
+$hashed-cert-uri-map /= {
+  "url": url-regexp-type, ; JUMBF URI reference
+  ? "alg": tstr .size (1..max-tstr-length), ; A string identifying the cryptographic hash algorithm used to compute all hashes in this claim, taken from the C2PA hash algorithm identifier list. If this field is absent, the hash algorithm is taken from an enclosing structure as defined by that structure. If both are present, the field in this structure is used. If no value is present in any of these places, this structure is invalid; there is no default.
+  ? "hash": bstr, ;  optional.  If present, the byte string representing the hash of the public key used in the referenced ID assertion.
+}
+
+; with CBOR Head (#) and tail ($) are introduced in regexp, so not needed explicitly
+url-regexp-type  /= tstr .regexp "self#jumbf=[\\w\\d][\\w\\d\\.\/:-]+[\\w\\d]"
+
 ----
 
 IMPORTANT: Future minor version updates (1.1, 1.2, etc.) to this specification MAY add new fields to the `signer-payload-map` description, provided that such new data members are optional and there is a well-specified default meaning that is compatible with the 1.0 version of this specification. Such updates to the specification SHOULD continue to use the `cawg.identity` assertion label.
@@ -275,6 +288,50 @@ IMPORTANT: Future minor version updates (1.1, 1.2, etc.) to this specification M
 Possible values for the `sig_type` field and the corresponding interpretations of the `signature` field are described in xref:_credentials_signatures_and_validation_methods[xrefstyle=full].
 
 The `hashed-uri-map` rule is defined in link:++https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_hashed_uris++[Section 8.3.1, “Hashed URIs,”] of the C2PA technical specification.
+There must be exactly one entry for each assertion in the claim, including the JUMBF URI of the ID assertion that is currently being created.
+
+Assertions can be referenced in two ways: If `hashed-uri-map.hash` is present, then the hash value should be set to the assertion-hash in the normal way and verifiers will check that the assertion-hash matches
+the value in `referenced_assertions`. 
+
+If `hashed-uri-map.hash` is not set, then verifiers will check the presence of the referenced assertion, but will not check the hash value. This option must be used for the ID assertion that is currently being created, because the hash is not yet known until the assertion is finalized.  
+
+NOTE: This specification requires all assertions be referenced in the `signer_payload` to guard against
+unauthorized additions of assertions to the Claim after the ID-assertion is signed.  ID-assertion creators are advised
+to also include the hash of the assertion wherever possible, because this also protects the referenced assertions against unauthorized modifications.  
+
+`claim_certificate_hash` (optional) is the hash of the leaf-certificate of the claim signing key.  ID-assertion-generators can set this field 
+to mitigate the threat of the authorized Claim Signature being stripped and replaced.  The hash is calculated over the leaf certificate of the Claim Signing 
+key using the same representation as used in the signature structure (i.e.,, DER for X.509).  
+
+`id_certificate_hash` (optional) is used when more than one ID-assertion is present in a Claim. 
+If more than one ID-assertion is present in a Claim, ID-assertion creators are advised to ensure 
+that later-created ID-assertions reference earlier-created assertions by including the hash of the assertion in `referenced-assertions`; this ensures that an ID assertion cannot be removed or 
+replaced without invalidating the later-created ID-assertion. However, this does not prevent a later-created ID assertion being replaced, because the hash of the later-created ID assertion is not yet known and cannot be set.
+To guard against later-generated ID-assertions being replaced, an ID-assertion creator can set an 
+entry in `id_certificate_hash` to the hash of the _certificate_ of the later-created ID assertion.  
+If this field is set, verifiers will ensure that the referenced ID assertion is signed with 
+the key that was authorized by the earlier-created ID assertion.  
+
+[NOTE]  
+====
+When ID assertions are employed, a Claim will contain two or more digital signatures from two or more entities with (possibly) 
+different levels of trust.  For some scenarios, stripping a Claim Signature and replacing it with a signature from a different Claim 
+Generator can result in misinterpretation, so this specification contains protections that ID assertion generators can use to guard
+against such attacks.
+
+It will generally not be possible for an attacker to strip and replace an ID assertion without invalidating the Manifest because the ID 
+assertion is hashed and included in the Claim Signature.  Unfortunately, it is not possible to incorporate the hash of the Claim signature in the ID assertion 
+to prevent Claim Signature stripping because the Claim Signature hash is not known at the time the ID assertion is signed.  To enable bidirectional ID-assertion binding, the 
+ID assertion generator can optionally include the hash of the Claim Signature signing key certificate.  If this is present, validators will
+check that the Claim Signature has been issued by the authorized Claim Generator.
+
+Similarly, when a Manifest contains more than one ID assertion, ID assertions that are signed later can include the hash of ID-assertions 
+generated earlier by means of an entry in the `referenced_assertions` array.  This guards against earlier ID assertions being 
+stripped and replaced, but does not protect against later generated ID assertions being replaced without the knowledge or 
+authorization of earlier ID assertion generators.  To guard against the latter attack, each ID assertion can include the hash of the certificate
+for ID assertions that will be generated later. 
+====
+
 
 ==== Example
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -218,25 +218,28 @@ This specification defines a _<<C2PA assertion>>_ known as an *<<_identity_asser
 
 The *<<_identity_assertion,identity assertion>>* contains the following data fields:
 
-* `signer_payload` contains the set of data to be signed by this _<<_credential_holder,credential holder>>_. This structure is a CBOR key-value map that contains:
-** `referenced_assertions` _(required)_ contains a list of other assertions selected by the credential subject. This is referred to as `signer_payload.referenced_assertions` throughout this specification.
+* `signer_payload` contains the set of data to be signed by this _<<_credential_holder,credential holder>>_. 
 * `signature` contains the raw byte stream of the _<<_credential_holder,credential holder>>’s_ signature
-* `sig_type` defines the data type of signature
 * `pad1` and `pad2` are byte strings filled with binary `0x00` values used to fill space
 
-The content of `signer_payload` is a data structure which is presented to the _<<_credential_holder,credential holder>>_ for signature. The list of _<<_referenced_assertions,referenced assertions>>_ contained within `signer_payload` MUST include a _<<hard_binding,hard binding>>_ assertion as described in link:++https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specification.html#_hard_bindings++[Section 9.2, “Hard bindings,”] of the C2PA technical specification.
+The `signer_payload` is a structure of type `signer-payload-map` which signed by the _<<_credential_holder,credential holder>>_. It contains the following fields:
 
-IMPORTANT: A single signature from the _<<_credential_holder,credential holder>>_ covers the entire `signer_payload` data structure, including the _list_ of assertions. An implementation MUST NOT present each assertion separately for signature.
+* `sig_type` is a string identifying the data type of the signature.  Valid credential types and the corresponding `signature` data structures and `sig_type` values are defined in xref:_credentials_signatures_and_validation_methods[xrefstyle=full].
 
-For each assertion listed in the `signer_payload.referenced_assertions` field of the *<<_identity_assertion,identity assertion>>,* an assertion with the same `url`, `alg`, and `hash` values MUST also be listed in the `assertions` field of the _<<C2PA claim>>_ in which the *<<_identity_assertion,identity assertion>>* appears.
+* `referenced_assertions` is an array of `hashed-uri-map` structures with one entry for
+every assertion in the Claim, including the current assertion. While every 
+assertion must be referenced, the hash may be omitted for all but one assertion.
+At least one _<<hard_binding,hard binding>>_ assertion as described in link:++https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specification.html#_hard_bindings++[Section 9.2, “Hard bindings,”] of the C2PA technical specification MUST be referenced by hash. Considerations for including or omitting the hash for other assertions are discussed in <<_Security Considerations for Creating Identity Assertions_,the next section>>.
 
-The list of _<<_referenced_assertions,referenced assertions>>_ in the `signer_payload.referenced_assertions` field of the *<<_identity_assertion,identity assertion>>* is necessarily a subset of the assertions listed in the `assertions` field of the _<<C2PA claim>>_ because the *<<_identity_assertion,identity assertion>>* MUST NOT refer to itself. The list of assertions MAY be further subsetted. For example, different _<<_credential_holder,credential holders>>_ could attest to different assertions in a single _<<C2PA Manifest>>._
+* `signer_info` (optional) is a string that provides additional information about the signer. This field may be used to encode human-readable information about the signer, such as their name or role. 
+
+* `claim_certificate_hash` (optional) is the hash of the leaf-certificate of the claim signing key.  ID-assertion-generators can set this field 
+to mitigate the threat of the authorized Claim Signature being stripped and replaced.  The hash is calculated over the leaf certificate of the Claim Signing 
+key using the same representation as used in the signature structure (i.e., DER for X.509). 
+
+* `id_certificate_hash` (optional) can be used when more than one ID-assertion is present in a Claim to specify the credentials authorized to sign other ID assertions.  If this field is set, verifiers will check that the referenced ID assertion is signed with the key specified here.
 
 Multiple identity assertions may be used in the same _<<C2PA Manifest>>_ to describe the distinct roles of multiple _<<_actor,actors>>_ in creating a single _<<C2PA asset>>._ This is illustrated in the xref:multiple-identity-assertions[multi-author example] from the conceptual overview.
-
-The `signer_payload.referenced_assertions` entry of the *<<_identity_assertion,identity assertion>>* MUST NOT reference any assertion more than once.
-
-The `signer_payload.referenced_assertions` entry of an *<<_identity_assertion,identity assertion>>* MAY reference any other *<<_identity_assertion,identity assertion>>.* Since every assertion referenced by an *<<_identity_assertion,identity assertion>>* MUST NOT change once presented to the _<<_credential_holder,credential holder>>_ for signature, care MUST be taken to ensure that no *<<_identity_assertion,identity assertion>>* references itself and that no cycle of references among *<<_identity_assertion,identity assertions>>* is created.
 
 The content of `signature` depends on the type of credential that is used. Valid credential types and the corresponding `signature` data structures and `sig_type` values are defined in xref:_credentials_signatures_and_validation_methods[xrefstyle=full].
 
@@ -250,6 +253,68 @@ NOTE: TO DO (link:https://github.com/creator-assertions/identity-assertion/issue
 
 [#describe-actor-role]
 NOTE: TO DO (link:https://github.com/creator-assertions/identity-assertion/issues/26[issue #26]): Describe credential holder’s role in relation to the asset.
+
+
+=== Security Considerations for Creating Identity Assertions
+
+Identity Assertions primarily allow a _<<_credential_holder,credential holder>>_ to 
+form a non-repudiable, tamper-evident binding between the _<<_credential_subject,credential subject>>_ and the list of _<<_referenced_assertions,referenced assertions>>._  In some cases, the identity assertion provides an additional trust signal over the information provided by the C2PA Claim Signature, and in other cases, the Identity Assertion is of primary interest, and the Claim Signature provides supplemental information.  
+
+The Identity Assertion straightforwardly supports the former (trust-signal) case, 
+because the Claim Signature integrity protects the identity assertion from stripping or replacement.  This means that the identity assertion cannot be tampered without invalidating the Claim Signature.
+
+However, the converse is not true. Without additional protections, the identity assertion 
+does not guard against the Claim Signature being stripped and replaced.  The mechanisms
+described in this section provide protections against this attack.
+
+The Claim Signature protects against stripping or modification of an identity assertion 
+because the hash of the identity assertion is included in the Claim Signature.  Unfortunately, it is not possible for the identity assertion to include the hash of the 
+Claim Signature because it is not known when the identity assertion is created.  This 
+specification provides a weaker binding that allows the identity assertion creator to 
+specify the key/certificate that is authorized to sign the Claim. This does not prevent a 
+Claim Signature being stripped and replaced by the _same_ Claim Signer, but it does prevent
+the Claim Signature from being replaced by a different Claim Signer.  To enable 
+this protection, the identity assertion creator can optionally include the hash of
+the Claim Signer credential/certificate authorized to (subsequently) sign the Claim.  If these
+protections are not needed (for example, if the identity assertion is expected to be
+a supplemental trust signal), then the `claim_certificate_hash` field can be omitted.
+
+Similar security considerations apply in the case of multiple identity  assertions.  If more than one identity assertion is present, then earlier-created identity assertions that 
+are referenced by hash by later-created identity assertions are protected from modification. 
+However, later-created identity assertions are not protected from being stripped and replaced.  This attack can be mitigated by each identity assertion stating the
+hash of the credentials/certificates that are authorized for use by other identity
+assertions, in a very similar way to how the `claim_certificate_hash` field is used.
+
+Finally, note that `referenced_assertions` field MUST include the JUMBF URI of _all_ of the
+assertions in this Claim, although the assertion hashes may be omitted (apart from for one hard-binding assertion). This guards against additional assertions being added that were not
+authorized by the identity assertion creator.  
+
+=== Requirements and Best Practice for Creating Identity Assertions
+The following are requirements and best practices for creating Identity Assertions:
+
+* Each identity assertion MUST reference itself and every other assertion in the 
+Claim by including its JUMBF URI in an entry in the `referenced_assertions` field. 
+The `hash` MAY be omitted in most cases, but considerations and recommendations
+for including the hash value are provided here. 
+
+* There MUST NOT be repeated entries in the `referenced_assertions` field.
+
+* An identity assertion MUST reference at least one hard binding assertion by hash. 
+
+* An identity assertion SHOULD include the hash of for all of the other assertions in the 
+Claim where possible.
+
+NOTE: This is not possible for the identity assertion itself, because the hash is not known until the assertion is finalized.  Nor is it possible for other identity assertions that 
+have not yet been signed.  Practically, the order of creation of identity assertions
+should be fixed before the assertions are created and signed, with the the most 
+accountable credential holders being finalized last.
+
+NOTE:  An assertion hash may be omitted for other reasons, including when the 
+identity assertion creator does not want to vouch for a particular assertion.
+
+* An identity assertion SHOULD populate the `claim_certificate_hash` field to mitigate the threat of the authorized Claim Signature being stripped and replaced. 
+
+* An identity assertion SHOULD  populate the `id_certificate_hash` field to specify the credentials authorized to sign other ID assertions.  This provides partial protection against identity assertions being stripped and replaced.
 
 === CBOR schema
 
@@ -275,7 +340,7 @@ signer-payload-map = {
 $hashed-cert-uri-map /= {
   "url": url-regexp-type, ; JUMBF URI reference
   ? "alg": tstr .size (1..max-tstr-length), ; A string identifying the cryptographic hash algorithm used to compute all hashes in this claim, taken from the C2PA hash algorithm identifier list. If this field is absent, the hash algorithm is taken from an enclosing structure as defined by that structure. If both are present, the field in this structure is used. If no value is present in any of these places, this structure is invalid; there is no default.
-  ? "hash": bstr, ;  optional.  If present, the byte string representing the hash of the public key used in the referenced ID assertion.
+  ? "hash": bstr, ;  optional.  If present, the byte string representing the hash of the certificate used to sign the the referenced ID assertion.
 }
 
 ; with CBOR Head (#) and tail ($) are introduced in regexp, so not needed explicitly
@@ -288,50 +353,6 @@ IMPORTANT: Future minor version updates (1.1, 1.2, etc.) to this specification M
 Possible values for the `sig_type` field and the corresponding interpretations of the `signature` field are described in xref:_credentials_signatures_and_validation_methods[xrefstyle=full].
 
 The `hashed-uri-map` rule is defined in link:++https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_hashed_uris++[Section 8.3.1, “Hashed URIs,”] of the C2PA technical specification.
-There must be exactly one entry for each assertion in the claim, including the JUMBF URI of the ID assertion that is currently being created.
-
-Assertions can be referenced in two ways: If `hashed-uri-map.hash` is present, then the hash value should be set to the assertion-hash in the normal way and verifiers will check that the assertion-hash matches
-the value in `referenced_assertions`. 
-
-If `hashed-uri-map.hash` is not set, then verifiers will check the presence of the referenced assertion, but will not check the hash value. This option must be used for the ID assertion that is currently being created, because the hash is not yet known until the assertion is finalized.  
-
-NOTE: This specification requires all assertions be referenced in the `signer_payload` to guard against
-unauthorized additions of assertions to the Claim after the ID-assertion is signed.  ID-assertion creators are advised
-to also include the hash of the assertion wherever possible, because this also protects the referenced assertions against unauthorized modifications.  
-
-`claim_certificate_hash` (optional) is the hash of the leaf-certificate of the claim signing key.  ID-assertion-generators can set this field 
-to mitigate the threat of the authorized Claim Signature being stripped and replaced.  The hash is calculated over the leaf certificate of the Claim Signing 
-key using the same representation as used in the signature structure (i.e.,, DER for X.509).  
-
-`id_certificate_hash` (optional) is used when more than one ID-assertion is present in a Claim. 
-If more than one ID-assertion is present in a Claim, ID-assertion creators are advised to ensure 
-that later-created ID-assertions reference earlier-created assertions by including the hash of the assertion in `referenced-assertions`; this ensures that an ID assertion cannot be removed or 
-replaced without invalidating the later-created ID-assertion. However, this does not prevent a later-created ID assertion being replaced, because the hash of the later-created ID assertion is not yet known and cannot be set.
-To guard against later-generated ID-assertions being replaced, an ID-assertion creator can set an 
-entry in `id_certificate_hash` to the hash of the _certificate_ of the later-created ID assertion.  
-If this field is set, verifiers will ensure that the referenced ID assertion is signed with 
-the key that was authorized by the earlier-created ID assertion.  
-
-[NOTE]  
-====
-When ID assertions are employed, a Claim will contain two or more digital signatures from two or more entities with (possibly) 
-different levels of trust.  For some scenarios, stripping a Claim Signature and replacing it with a signature from a different Claim 
-Generator can result in misinterpretation, so this specification contains protections that ID assertion generators can use to guard
-against such attacks.
-
-It will generally not be possible for an attacker to strip and replace an ID assertion without invalidating the Manifest because the ID 
-assertion is hashed and included in the Claim Signature.  Unfortunately, it is not possible to incorporate the hash of the Claim signature in the ID assertion 
-to prevent Claim Signature stripping because the Claim Signature hash is not known at the time the ID assertion is signed.  To enable bidirectional ID-assertion binding, the 
-ID assertion generator can optionally include the hash of the Claim Signature signing key certificate.  If this is present, validators will
-check that the Claim Signature has been issued by the authorized Claim Generator.
-
-Similarly, when a Manifest contains more than one ID assertion, ID assertions that are signed later can include the hash of ID-assertions 
-generated earlier by means of an entry in the `referenced_assertions` array.  This guards against earlier ID assertions being 
-stripped and replaced, but does not protect against later generated ID assertions being replaced without the knowledge or 
-authorization of earlier ID assertion generators.  To guard against the latter attack, each ID assertion can include the hash of the certificate
-for ID assertions that will be generated later. 
-====
-
 
 ==== Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cawg-identity",
+  "name": "identity-assertion",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This is a partial/incomplete description of the security fixes identified in https://github.com/creator-assertions/identity-assertion/issues/95

These changes will need corresponding changes elsewhere in the spec, especially in the validation section, but this will be added once we have settled on the changes here.