### PR TITLE
Remove requirement for `id` field

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -861,13 +861,6 @@ The `validFrom` field MUST exist and it MUST express the date and time when the 
 
 NOTE: TO DO (link:https://github.com/creator-assertions/identity-assertion/issues/64[issue #64]): Consider stronger timestamping mechanism than W3C VC requires.
 
-[#vc-credentialsubject-id]
-===== ID
-
-The `id` property MUST be present and MUST represent an URI. It is RECOMMENDED that the URI be one which, if dereferenced, results in a globally unambiguous status of existence of the _<<_named_actor,named actor>>_. For example, dereferencing a `did:web` might return a `204 No Content` HTTP status code in case the user exists and no further information is available or `404 Not Found` HTTP status code in case the user does not exist.
-
-NOTE: TO DO: Consider removing this section. This section doesn't add much information over the existing W3C VC requirements except the requirement to have an `id` field and I'm not sure that's actually necessary.
-
 [#vc-credentialsubject-namedactor]
 ===== Named actor
 

--- a/docs/modules/ROOT/partials/version-history.adoc
+++ b/docs/modules/ROOT/partials/version-history.adoc
@@ -54,3 +54,4 @@ _This section is non-normative._
 *29 July 2024*
 
 * Merge with updated 1.0-draft version of this specification.
+* Remove requirement for credential identity assertion to have an `id` field.


### PR DESCRIPTION
I don't think we need to require an ID for the asset-specific credential.

See https://creator-assertions.github.io/identity/1.x+vc-draft/#pr-147.